### PR TITLE
Makefile: Adding 'deps' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,8 @@ $(BOOKNAME).html: $(BOOKNAME).txt Makefile
 clean:
 	rm -rf $(TARGET) $(BOOKNAME)__*.png
 
+deps:
+	# Needed packages on a Fedora system
+	lsb_release -is | grep -qw Fedora && dnf install asciidoc dblatex texlive-euenc texlive-wallpaper adobe-source-sans-pro-fonts
+
 .PHONY: clean release

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This toolchain has been created and is used in the first place to publish
 - [Ghostscript]
 - [Docbook]
 
+If you run on a Fedora system, just run the `deps` target of the makefile as root to install them like in :
+
+ - sudo make deps
+
 ## Usage
 
 The book content should be written in the `book.txt` source file. Once you've


### PR DESCRIPTION
When running this software on a Fedora host, it takes some time before
being able to compile the book.pdf example.

This patch add 'deps' target that check if the required packages are
properly installed.